### PR TITLE
APP-34004: chore(renovate): Adding non-esm back configs

### DIFF
--- a/renovate/ts-lib-service-non-esm.json
+++ b/renovate/ts-lib-service-non-esm.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>habx/devops-repo-shared-configs//renovate/ts-back-non-esm",
+    "github>habx/devops-repo-shared-configs//renovate/ts-npmrc-private"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "addLabels": [
+        "automerge-noupdate"
+      ]
+    },
+    {
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "depTypeList": [
+        "dependencies",
+        "peerDependencies"
+      ],
+      "addLabels": [
+        "automerge-noupdate"
+      ]
+    }
+  ]
+}

--- a/renovate/ts-service-non-esm.json
+++ b/renovate/ts-service-non-esm.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>habx/devops-repo-shared-configs//renovate/ts-back-non-esm",
+    "github>habx/devops-repo-shared-configs//renovate/ts-npmrc-private"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "addLabels": [
+        "automerge-noupdate"
+      ]
+    }
+  ]
+}

--- a/renovate/ts-tool-non-esm.json
+++ b/renovate/ts-tool-non-esm.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>habx/devops-repo-shared-configs//renovate/ts-back-non-esm",
+    "github>habx/devops-repo-shared-configs//renovate/ts-npmrc-private"
+  ],
+  "packageRules": [
+    {
+      "updateTypes": [
+        "major",
+        "minor",
+        "patch"
+      ],
+      "depTypeList": [
+        "devDependencies"
+      ],
+      "addLabels": [
+        "automerge-noupdate"
+      ]
+    },
+    {
+      "updateTypes": [
+        "minor",
+        "patch"
+      ],
+      "depTypeList": [
+        "dependencies",
+        "peerDependencies"
+      ],
+      "addLabels": [
+        "automerge-noupdate"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
See [APP-34004](https://habxfr.atlassian.net/browse/APP-34004): devops-repo-shared-configs: chore(renovate): Adding a non-esm back config.

